### PR TITLE
improve reprPoint calculations from contained locations

### DIFF
--- a/pleiades/geographer/geo.py
+++ b/pleiades/geographer/geo.py
@@ -554,15 +554,9 @@ class PlaceReprPt(object):
     @memoize
     def reprPoint(self):
         located = PlaceLocated(self.context)
-        # The first item in the tuple sorts None above all other values. The second item sorts lower
-        # values before higher values
-        best_first = lambda location: (
-                location.getAccuracy().value is None if location.getAccuracy() else True,
-                location.getAccuracy() and location.getAccuracy().value or None
-            )
-        geoms = located.preciseGeoms(sort_key=best_first)
+        geoms = located.preciseGeoms()
         if geoms:
-            centroid = self.average_centroid_of_geometries(geoms[:1])
+            centroid = self.average_centroid_of_geometries(geoms)
             return centroid[0], centroid[1], "precise"
 
         try:


### PR DESCRIPTION
stop using horizontal accuracy to sort locations for reprPoint calculation; stop selecting only the first/best location for reprPoint calculation. Fixes https://github.com/isawnyu/pleiades-gazetteer/issues/446